### PR TITLE
fix: upgrade serverless express engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@angular/common": "^12.1.0",
         "@netlify/functions": "^0.7.2",
-        "aws-serverless-express": "^3.4.0",
+        "@vendia/serverless-express": "^4.3.9",
         "chalk": "^2.4.2",
         "fs-extra": "^9.1.0",
         "zone.js": "^0.11.4"
@@ -3047,14 +3047,11 @@
       }
     },
     "node_modules/@vendia/serverless-express": {
-      "version": "3.4.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "binary-case": "^1.0.0",
-        "type-is": "^1.6.16"
-      },
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@vendia/serverless-express/-/serverless-express-4.3.9.tgz",
+      "integrity": "sha512-lfnnnJ/J9rpa4tDqkPzDMmJr+c489YI81i7P9JWZyf3zAKowaF0t1SeR3g9zUJYmTOn9glmqjiaG+OvNvxY7UQ==",
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -3852,18 +3849,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/aws-serverless-express": {
-      "version": "3.4.0",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@vendia/serverless-express": "^3.4.0",
-        "binary-case": "^1.0.0",
-        "type-is": "^1.6.16"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
       "dev": true,
@@ -4114,10 +4099,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/binary-case": {
-      "version": "1.1.4",
-      "license": "Apache-2.0"
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -11878,6 +11859,7 @@
     },
     "node_modules/media-typer": {
       "version": "0.3.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12204,6 +12186,7 @@
     },
     "node_modules/mime-db": {
       "version": "1.48.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
@@ -12211,6 +12194,7 @@
     },
     "node_modules/mime-types": {
       "version": "2.1.31",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mime-db": "1.48.0"
@@ -19380,6 +19364,7 @@
     },
     "node_modules/type-is": {
       "version": "1.6.18",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "media-typer": "0.3.0",
@@ -23170,11 +23155,9 @@
       }
     },
     "@vendia/serverless-express": {
-      "version": "3.4.0",
-      "requires": {
-        "binary-case": "^1.0.0",
-        "type-is": "^1.6.16"
-      }
+      "version": "4.3.9",
+      "resolved": "https://registry.npmjs.org/@vendia/serverless-express/-/serverless-express-4.3.9.tgz",
+      "integrity": "sha512-lfnnnJ/J9rpa4tDqkPzDMmJr+c489YI81i7P9JWZyf3zAKowaF0t1SeR3g9zUJYmTOn9glmqjiaG+OvNvxY7UQ=="
     },
     "@webassemblyjs/ast": {
       "version": "1.11.1",
@@ -23709,14 +23692,6 @@
         }
       }
     },
-    "aws-serverless-express": {
-      "version": "3.4.0",
-      "requires": {
-        "@vendia/serverless-express": "^3.4.0",
-        "binary-case": "^1.0.0",
-        "type-is": "^1.6.16"
-      }
-    },
     "aws-sign2": {
       "version": "0.7.0",
       "dev": true
@@ -23883,9 +23858,6 @@
     "big.js": {
       "version": "5.2.2",
       "dev": true
-    },
-    "binary-case": {
-      "version": "1.1.4"
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -29005,7 +28977,8 @@
       "dev": true
     },
     "media-typer": {
-      "version": "0.3.0"
+      "version": "0.3.0",
+      "dev": true
     },
     "mem": {
       "version": "8.1.1",
@@ -29221,10 +29194,12 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.48.0"
+      "version": "1.48.0",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.31",
+      "dev": true,
       "requires": {
         "mime-db": "1.48.0"
       }
@@ -33856,6 +33831,7 @@
     },
     "type-is": {
       "version": "1.6.18",
+      "dev": true,
       "requires": {
         "media-typer": "0.3.0",
         "mime-types": "~2.1.24"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
   "dependencies": {
     "@angular/common": "^12.1.0",
     "@netlify/functions": "^0.7.2",
-    "aws-serverless-express": "^3.4.0",
+    "@vendia/serverless-express": "^4.3.9",
     "chalk": "^2.4.2",
     "fs-extra": "^9.1.0",
     "zone.js": "^0.11.4"

--- a/src/helpers/getDynamicTemplates.js
+++ b/src/helpers/getDynamicTemplates.js
@@ -1,23 +1,24 @@
 const getAngularBuilder = ({ functionServerPath }) => `
   const { builder } = require('@netlify/functions')
-  const awsServerlessExpress = require('aws-serverless-express')
-  const awsServerlessExpressMiddleware = require('aws-serverless-express/middleware')
-
-  // eslint-disable-next-line node/no-missing-require, node/no-unpublished-require
+  const serverlessExpress = require('@vendia/serverless-express')
 
   const server = require('${functionServerPath}')
 
-  // makes event and context available to app
-  server.app.use(awsServerlessExpressMiddleware.eventContext())
-
-  const serverProxy = awsServerlessExpress.createServer(server.app)
-
-  const handler = (event, context) => awsServerlessExpress.proxy(serverProxy, event, context, 'PROMISE').promise
+  const handler = async (event, context) => {
+    try {
+      const serverlessHandler = await serverlessExpress({ app: server.app, eventSourceName: 'AWS_API_GATEWAY_V1' })
+      const response = await serverlessHandler(event, context)
+      return response
+    } catch (e) {
+      return {
+        statusCode: 404
+      }
+    }
+  }
 
   exports.handler = builder(handler)
 `
 
-// TO-DO: improve error handling
 const getServerlessTs = ({ projectName, siteRoot }) => `
   import 'zone.js/dist/zone-node'
 


### PR DESCRIPTION
did this as a way to figure out how to handle uncaught errors thrown in angular express rendering. this doesn't resolve the error stuff, but it does use the new serverless-express package (aws-serverless-express was deprecated) and 4.x instead of 3.x. 

spent a day trying to figure out the angular error stuff so we don't get function timeouts when accessing routes that don't exist in a user's angular site. no dice. left a comment here: https://github.com/angular/universal/issues/2162#issuecomment-890283213