### PR TITLE
fix: resolves defaultProject angular.json changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,9 @@ dist
 .AppleDouble
 .LSOverride
 
+### IDE ###
+.idea
+
 # Icon must end with two \r
 Icon
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ Right now:
 - it does not include out of the box monorepo support
 - it does not support Angular Universal prerendering
 
+### Project Name
+
+The plugin will attempt to find your default Angular project.
+Should you have multiple Angular applications in the same
+repository, you will need to add the project name to
+your `angular.json`:
+
+```json
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "defaultProject": "{projectName}",
+  ...
+}
+```
+
 ## Getting Help
 
 We love to hear from you so if you have questions, comments or find a bug in the

--- a/demo/angular.json
+++ b/demo/angular.json
@@ -1,1 +1,196 @@
-{"$schema":"./node_modules/@angular/cli/lib/config/schema.json","cli":{"analytics":false},"version":1,"newProjectRoot":"projects","projects":{"angular-bfdx":{"projectType":"application","schematics":{},"root":"","sourceRoot":"src","prefix":"app","architect":{"build":{"builder":"@angular-devkit/build-angular:browser","options":{"outputPath":"dist/angular-bfdx/browser","index":"src/index.html","main":"src/main.ts","polyfills":"src/polyfills.ts","tsConfig":"tsconfig.app.json","aot":true,"assets":["src/favicon.ico","src/assets"],"styles":["src/site.css","src/mobile.css"],"scripts":[]},"configurations":{"production":{"fileReplacements":[{"replace":"src/environments/environment.ts","with":"src/environments/environment.prod.ts"}],"optimization":true,"outputHashing":"none","sourceMap":false,"namedChunks":false,"extractLicenses":true,"vendorChunk":false,"buildOptimizer":true,"budgets":[{"type":"initial","maximumWarning":"2mb","maximumError":"5mb"},{"type":"anyComponentStyle","maximumWarning":"6kb","maximumError":"10kb"}]}}},"serve":{"builder":"@angular-devkit/build-angular:dev-server","options":{"browserTarget":"angular-bfdx:build"},"configurations":{"production":{"browserTarget":"angular-bfdx:build:production"}}},"extract-i18n":{"builder":"@angular-devkit/build-angular:extract-i18n","options":{"browserTarget":"angular-bfdx:build"}},"test":{"builder":"@angular-devkit/build-angular:karma","options":{"main":"src/test.ts","polyfills":"src/polyfills.ts","tsConfig":"tsconfig.spec.json","karmaConfig":"karma.conf.js","assets":["src/favicon.ico","src/assets"],"styles":["src/styles.css"],"scripts":[]}},"lint":{"builder":"@angular-devkit/build-angular:tslint","options":{"tsConfig":["tsconfig.app.json","tsconfig.spec.json","e2e/tsconfig.json","tsconfig.server.json"],"exclude":["**/node_modules/**"]}},"e2e":{"builder":"@angular-devkit/build-angular:protractor","options":{"protractorConfig":"e2e/protractor.conf.js","devServerTarget":"angular-bfdx:serve"},"configurations":{"production":{"devServerTarget":"angular-bfdx:serve:production"}}},"server":{"builder":"@angular-devkit/build-angular:server","options":{"outputPath":"dist/angular-bfdx/server","main":"server.ts","tsConfig":"tsconfig.server.json"},"configurations":{"production":{"outputHashing":"media","fileReplacements":[{"replace":"src/environments/environment.ts","with":"src/environments/environment.prod.ts"}],"sourceMap":false,"optimization":true}}},"serve-ssr":{"builder":"@nguniversal/builders:ssr-dev-server","options":{"browserTarget":"angular-bfdx:build","serverTarget":"angular-bfdx:server"},"configurations":{"production":{"browserTarget":"angular-bfdx:build:production","serverTarget":"angular-bfdx:server:production"}}},"prerender":{"builder":"@nguniversal/builders:prerender","options":{"browserTarget":"angular-bfdx:build:production","serverTarget":"angular-bfdx:server:production","routes":["/"]},"configurations":{"production":{}}},"serverless":{"builder":"@angular-devkit/build-angular:server","options":{"outputPath":"dist/angular-bfdx/serverless","main":"serverless.ts","tsConfig":"tsconfig.serverless.json"},"configurations":{"production":{"outputHashing":"media","fileReplacements":[{"replace":"src/environments/environment.ts","with":"src/environments/environment.prod.ts"}],"sourceMap":false,"optimization":true}}}}}},"defaultProject":"angular-bfdx"}
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "cli": {
+    "analytics": false
+  },
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "angular-bfdx": {
+      "projectType": "application",
+      "schematics": {},
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/angular-bfdx/browser",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "aot": true,
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/site.css",
+              "src/mobile.css"
+            ],
+            "scripts": []
+          },
+          "configurations": {
+            "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "optimization": true,
+              "outputHashing": "none",
+              "sourceMap": false,
+              "namedChunks": false,
+              "extractLicenses": true,
+              "vendorChunk": false,
+              "buildOptimizer": true,
+              "budgets": [
+                {
+                  "type": "initial",
+                  "maximumWarning": "2mb",
+                  "maximumError": "5mb"
+                },
+                {
+                  "type": "anyComponentStyle",
+                  "maximumWarning": "6kb",
+                  "maximumError": "10kb"
+                }
+              ]
+            }
+          }
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "options": {
+            "browserTarget": "angular-bfdx:build"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "angular-bfdx:build:production"
+            }
+          }
+        },
+        "extract-i18n": {
+          "builder": "@angular-devkit/build-angular:extract-i18n",
+          "options": {
+            "browserTarget": "angular-bfdx:build"
+          }
+        },
+        "test": {
+          "builder": "@angular-devkit/build-angular:karma",
+          "options": {
+            "main": "src/test.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.spec.json",
+            "karmaConfig": "karma.conf.js",
+            "assets": [
+              "src/favicon.ico",
+              "src/assets"
+            ],
+            "styles": [
+              "src/styles.css"
+            ],
+            "scripts": []
+          }
+        },
+        "lint": {
+          "builder": "@angular-devkit/build-angular:tslint",
+          "options": {
+            "tsConfig": [
+              "tsconfig.app.json",
+              "tsconfig.spec.json",
+              "e2e/tsconfig.json",
+              "tsconfig.server.json"
+            ],
+            "exclude": [
+              "**/node_modules/**"
+            ]
+          }
+        },
+        "e2e": {
+          "builder": "@angular-devkit/build-angular:protractor",
+          "options": {
+            "protractorConfig": "e2e/protractor.conf.js",
+            "devServerTarget": "angular-bfdx:serve"
+          },
+          "configurations": {
+            "production": {
+              "devServerTarget": "angular-bfdx:serve:production"
+            }
+          }
+        },
+        "server": {
+          "builder": "@angular-devkit/build-angular:server",
+          "options": {
+            "outputPath": "dist/angular-bfdx/server",
+            "main": "server.ts",
+            "tsConfig": "tsconfig.server.json"
+          },
+          "configurations": {
+            "production": {
+              "outputHashing": "media",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "sourceMap": false,
+              "optimization": true
+            }
+          }
+        },
+        "serve-ssr": {
+          "builder": "@nguniversal/builders:ssr-dev-server",
+          "options": {
+            "browserTarget": "angular-bfdx:build",
+            "serverTarget": "angular-bfdx:server"
+          },
+          "configurations": {
+            "production": {
+              "browserTarget": "angular-bfdx:build:production",
+              "serverTarget": "angular-bfdx:server:production"
+            }
+          }
+        },
+        "prerender": {
+          "builder": "@nguniversal/builders:prerender",
+          "options": {
+            "browserTarget": "angular-bfdx:build:production",
+            "serverTarget": "angular-bfdx:server:production",
+            "routes": [
+              "/"
+            ]
+          },
+          "configurations": {
+            "production": {}
+          }
+        },
+        "serverless": {
+          "builder": "@angular-devkit/build-angular:server",
+          "options": {
+            "outputPath": "dist/angular-bfdx/serverless",
+            "main": "serverless.ts",
+            "tsConfig": "tsconfig.serverless.json"
+          },
+          "configurations": {
+            "production": {
+              "outputHashing": "media",
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
+              "sourceMap": false,
+              "optimization": true
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/examples/advanced-routing/angular.json
+++ b/examples/advanced-routing/angular.json
@@ -132,6 +132,5 @@
         }
       }
     }
-  },
-  "defaultProject": "angular-tour-of-heroes"
+  }
 }

--- a/src/helpers/getAngularProjectName.js
+++ b/src/helpers/getAngularProjectName.js
@@ -1,0 +1,23 @@
+const getAngularProjectName = ({ failBuild, angularJson }) => {
+  const { defaultProject, projects } = angularJson
+
+  if (defaultProject) {
+    return defaultProject
+  }
+
+  const projectKeys = Object.keys(projects)
+
+  if (projectKeys.length === 0) {
+    return failBuild(`Could not find any projects within angular.json`)
+  }
+
+  if (projectKeys.length > 1) {
+    return failBuild(
+      `Could not determine the default project name, please add it to your angular.json as "defaultProject"`,
+    )
+  }
+
+  return projectKeys[0]
+}
+
+module.exports = getAngularProjectName

--- a/src/helpers/setUpFunctionsConfig.js
+++ b/src/helpers/setUpFunctionsConfig.js
@@ -1,12 +1,8 @@
-const getAngularJson = require('./getAngularJson')
-
 // Modify [functions] of netlify config
-const setUpFunctionsConfig = function ({ angularJson, netlifyConfig, PUBLISH_DIR }) {
+const setUpFunctionsConfig = function ({ project, netlifyConfig, PUBLISH_DIR }) {
   netlifyConfig.functions.node_bundler = 'esbuild'
 
-  const includeStyles = angularJson.projects[angularJson.defaultProject].architect.build.options.styles.map(
-    (s) => `${PUBLISH_DIR}/${s.replace('src/', '')}`,
-  )
+  const includeStyles = project.architect.build.options.styles.map((s) => `${PUBLISH_DIR}/${s.replace('src/', '')}`)
 
   const includedDist = [`${PUBLISH_DIR}/index.html`, `${PUBLISH_DIR}/styles.css`, ...includeStyles]
   if (Array.isArray(netlifyConfig.functions.included_files)) {

--- a/src/helpers/updateAngularJson.js
+++ b/src/helpers/updateAngularJson.js
@@ -5,7 +5,7 @@ const { writeJsonSync } = require('fs-extra')
 // Add necessary serverless script to angular.json
 const updateAngularJson = function ({ failBuild, angularJson, projectName, siteRoot }) {
   if (!projectName) {
-    return failBuild('No value defined for projectName. Check plugin inputs in netlify.toml.')
+    return failBuild('No value defined for projectName.')
   }
 
   if (!angularJson.projects[projectName]) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const addAngularServerlessFiles = require('./helpers/addAngularServerlessFiles')
 const getAngularJson = require('./helpers/getAngularJson')
+const getAngularProjectName = require('./helpers/getAngularProjectName')
 const getAngularRoot = require('./helpers/getAngularRoot')
 const setUpBuilderFunction = require('./helpers/setUpBuilderFunction')
 const setUpFunctionsConfig = require('./helpers/setUpFunctionsConfig')
@@ -18,7 +19,7 @@ module.exports = {
 
     const angularJson = getAngularJson({ failBuild, siteRoot })
 
-    const projectName = angularJson.defaultProject
+    const projectName = getAngularProjectName({ failBuild, angularJson })
 
     updateAngularJson({ angularJson, failBuild, projectName, siteRoot })
 
@@ -37,11 +38,13 @@ module.exports = {
 
     const angularJson = getAngularJson({ failBuild, siteRoot })
 
-    const projectName = angularJson.defaultProject
+    const projectName = getAngularProjectName({ failBuild, angularJson })
+
+    const project = angularJson.projects[projectName]
 
     setUpRedirects({ netlifyConfig })
 
-    setUpFunctionsConfig({ angularJson, netlifyConfig, PUBLISH_DIR })
+    setUpFunctionsConfig({ project, netlifyConfig, PUBLISH_DIR })
 
     setUpBuilderFunction({
       FUNCTIONS_SRC: INTERNAL_FUNCTIONS_SRC || FUNCTIONS_SRC,


### PR DESCRIPTION
In newer versions of Angular, `defaultProject` is no longer added to `angular.json`.

This change alerts the user to re-add `defaultProject` (not a breaking change to the schema) if there are multiple projects.

If there is a single project, this will be returned by default.