### PR TITLE
fix: handle index page

### DIFF
--- a/src/helpers/setUpRedirects.js
+++ b/src/helpers/setUpRedirects.js
@@ -9,6 +9,13 @@ const setUpRedirects = function ({ netlifyConfig }) {
     to: '/.netlify/functions/angular-builder',
     status: 200,
   })
+  // This redirect is here to handle the "index" default redirection
+  netlifyConfig.redirects.push({
+    from: '/',
+    to: '/.netlify/functions/angular-builder',
+    force: true,
+    status: 200,
+  })
 }
 
 module.exports = setUpRedirects


### PR DESCRIPTION
The `/*` redirection will not overrides the default redirection of the `/` route to `index.html`, which will not be pre-rendered because.
This can be verified by cloning this repository and deploying it on Netlify, I made a test here: https://astounding-druid-97c6ce.netlify.app
Going to the home page with javascript disabled will just return a blank page, because `index.html` will be serve, which doesn't include any content.
I'm using the `force = true` because "/" route redirects by default to `index.html` which exists in `dist/{projectName}/browser`

A workaround is to add this redirection to the `netlify.toml` file of the project using this plugin:
```toml
[[plugins]]
  package = "@netlify/plugin-angular-universal"

[[redirects]]
  from = "/"
  to = "/.netlify/functions/angular-builder"
  force = true
  status = 200
```