### PR TITLE
fix: validate publish dir in buildbot

### DIFF
--- a/src/helpers/fixOutputDir.js
+++ b/src/helpers/fixOutputDir.js
@@ -1,12 +1,9 @@
 const { join } = require('path')
-const process = require('process')
 
 const getAngularJson = require('./getAngularJson')
 const { getProject } = require('./setUpEdgeFunction')
 
-const fixOutputDir = async function ({ failBuild, siteRoot, PUBLISH_DIR, netlifyConfig }) {
-  const isBuildbot = process.env.CI
-
+const fixOutputDir = async function ({ failBuild, siteRoot, PUBLISH_DIR, IS_LOCAL, netlifyConfig }) {
   const angularJson = getAngularJson({ failBuild, siteRoot })
   const project = getProject(angularJson)
 
@@ -17,11 +14,11 @@ const fixOutputDir = async function ({ failBuild, siteRoot, PUBLISH_DIR, netlify
     return
   }
 
-  if (isBuildbot) {
-    failBuild(`Publish directory is configured incorrectly. Please set it to "${correctPublishDir}".`)
-  } else {
+  if (IS_LOCAL) {
     console.warn(`Publish directory is configured incorrectly. Updating to "${correctPublishDir}".`)
     netlifyConfig.build.publish = correctPublishDir
+  } else {
+    failBuild(`Publish directory is configured incorrectly. Please set it to "${correctPublishDir}".`)
   }
 }
 

--- a/src/helpers/fixOutputDir.js
+++ b/src/helpers/fixOutputDir.js
@@ -1,0 +1,28 @@
+const { join } = require('path')
+const process = require('process')
+
+const getAngularJson = require('./getAngularJson')
+const { getProject } = require('./setUpEdgeFunction')
+
+const fixOutputDir = async function ({ failBuild, siteRoot, PUBLISH_DIR, netlifyConfig }) {
+  const isBuildbot = process.env.CI
+
+  const angularJson = getAngularJson({ failBuild, siteRoot })
+  const project = getProject(angularJson)
+
+  const { outputPath } = project.architect.build.options
+
+  const correctPublishDir = join(outputPath, 'browser')
+  if (correctPublishDir === PUBLISH_DIR) {
+    return
+  }
+
+  if (isBuildbot) {
+    failBuild(`Publish directory is configured incorrectly. Please set it to "${correctPublishDir}".`)
+  } else {
+    console.warn(`Publish directory is configured incorrectly. Updating to "${correctPublishDir}".`)
+    netlifyConfig.build.publish = correctPublishDir
+  }
+}
+
+module.exports = fixOutputDir

--- a/src/helpers/setUpEdgeFunction.js
+++ b/src/helpers/setUpEdgeFunction.js
@@ -20,8 +20,15 @@ const getAllFilesIn = (dir) =>
 
 const toPosix = (path) => path.split(sep).join(posix.sep)
 
-const setUpEdgeFunction = async ({ angularJson, projectName, netlifyConfig, constants, failBuild }) => {
-  const project = angularJson.projects[projectName]
+const getProject = (angularJson) => {
+  const projectName = angularJson.defaultProject ?? Object.keys(angularJson.projects)[0]
+  return angularJson.projects[projectName]
+}
+
+module.exports.getProject = getProject
+
+const setUpEdgeFunction = async ({ angularJson, constants, failBuild }) => {
+  const project = getProject(angularJson)
   const {
     architect: { build },
   } = project
@@ -30,15 +37,13 @@ const setUpEdgeFunction = async ({ angularJson, projectName, netlifyConfig, cons
     return failBuild('Could not find build output directory')
   }
 
-  netlifyConfig.build.publish = join(outputDir, 'browser')
-
   const serverDistRoot = join(outputDir, 'server')
   if (!existsSync(serverDistRoot)) {
     console.log('No server output generated, skipping SSR setup.')
     return
   }
 
-  console.log(`Writing Angular SSR Edge Function for project "${projectName}" ...`)
+  console.log(`Writing Angular SSR Edge Function ...`)
 
   const edgeFunctionDir = join(constants.INTERNAL_EDGE_FUNCTIONS_SRC, 'angular-ssr')
   await mkdir(edgeFunctionDir, { recursive: true })
@@ -101,4 +106,4 @@ const setUpEdgeFunction = async ({ angularJson, projectName, netlifyConfig, cons
   await writeFile(join(edgeFunctionDir, 'angular-ssr.mjs'), ssrFunction)
 }
 
-module.exports = setUpEdgeFunction
+module.exports.setUpEdgeFunction = setUpEdgeFunction

--- a/src/index.js
+++ b/src/index.js
@@ -2,9 +2,10 @@ const { rm } = require('fs/promises')
 const { join } = require('path')
 
 const ensureNoCompetingPlugin = require('./helpers/ensureNoCompetingPlugin')
+const fixOutputDir = require('./helpers/fixOutputDir')
 const getAngularJson = require('./helpers/getAngularJson')
 const getAngularRoot = require('./helpers/getAngularRoot')
-const setUpEdgeFunction = require('./helpers/setUpEdgeFunction')
+const { setUpEdgeFunction } = require('./helpers/setUpEdgeFunction')
 const validateAngularVersion = require('./helpers/validateAngularVersion')
 
 let isValidAngularProject = true
@@ -17,7 +18,7 @@ module.exports = {
     const edgeFunctionDir = join(constants.INTERNAL_EDGE_FUNCTIONS_SRC, 'angular-ssr')
     await rm(edgeFunctionDir, { recursive: true })
   },
-  async onPreBuild({ netlifyConfig, utils }) {
+  async onPreBuild({ netlifyConfig, utils, constants }) {
     const siteRoot = getAngularRoot({ netlifyConfig })
     isValidAngularProject = await validateAngularVersion(siteRoot)
     if (!isValidAngularProject) {
@@ -28,6 +29,13 @@ module.exports = {
     ensureNoCompetingPlugin(siteRoot, utils.build.failBuild)
 
     netlifyConfig.build.command ??= 'npm run build'
+
+    await fixOutputDir({
+      siteRoot,
+      failBuild: utils.build.failBuild,
+      PUBLISH_DIR: constants.PUBLISH_DIR,
+      netlifyConfig,
+    })
   },
   async onBuild({ utils, netlifyConfig, constants }) {
     if (!isValidAngularProject) {
@@ -39,11 +47,8 @@ module.exports = {
     const siteRoot = getAngularRoot({ netlifyConfig })
     const angularJson = getAngularJson({ failBuild, siteRoot })
 
-    const projectName = angularJson.defaultProject ?? Object.keys(angularJson.projects)[0]
-
     await setUpEdgeFunction({
       angularJson,
-      projectName,
       constants,
       netlifyConfig,
       failBuild,

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,7 @@ module.exports = {
       siteRoot,
       failBuild: utils.build.failBuild,
       PUBLISH_DIR: constants.PUBLISH_DIR,
+      IS_LOCAL: constants.IS_LOCAL,
       netlifyConfig,
     })
   },


### PR DESCRIPTION
We realised that in buildbot deploys, we can't override the publish dir. We're now auto-detecting the right publish dir in https://github.com/netlify/build/pull/5373. Additionally, this PR adds some validation logic that catches whenever the project changes the publish dir.