### PR TITLE
fix: install run-s and run-p

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@netlify/angular-runtime",
       "version": "2.0.1",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "semver": "^7.5.4"
@@ -17,6 +17,7 @@
         "@types/node": "^16.3.1",
         "eslint-plugin-unicorn": "^49.0.0",
         "husky": "^4.3.0",
+        "npm-run-all": "^4.1.5",
         "prettier": "^2.1.2"
       },
       "engines": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@types/node": "^16.3.1",
     "eslint-plugin-unicorn": "^49.0.0",
     "husky": "^4.3.0",
+    "npm-run-all": "^4.1.5",
     "prettier": "^2.1.2"
   },
   "dependencies": {


### PR DESCRIPTION
Release-please is failing to publish because `npm-run-all` dependency is missing.