### PR TITLE
fix: remove `global` polyfill

### DIFF
--- a/src/helpers/setUpEdgeFunction.js
+++ b/src/helpers/setUpEdgeFunction.js
@@ -62,7 +62,6 @@ const setUpEdgeFunction = async ({ angularJson, constants, failBuild }) => {
   import process from "node:process"
 
   globalThis.process = process
-  globalThis.global = globalThis
   globalThis.DenoEvent = globalThis.Event // storing this for fixup-event.mjs
   `
 


### PR DESCRIPTION
The Angular team reminded me that `global` isn't needed anymore in v17+. Tested it, and they're right - removing it doesn't break anything! Better remove this quick, before customers start relying on it :D