### PR TITLE
fix: install before publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,11 +17,7 @@
     "format:check-fix:prettier": "run-e format:check:prettier format:fix:prettier",
     "format:check:prettier": "cross-env-shell prettier --check $npm_package_config_prettier",
     "format:fix:prettier": "cross-env-shell prettier --write $npm_package_config_prettier",
-    "prepublishOnly": "run-s prepublishOnly:*",
-    "prepublishOnly:checkout": "git checkout main",
-    "prepublishOnly:pull": "git pull",
-    "prepublishOnly:install": "npm ci",
-    "prepublishOnly:test": "npm test",
+    "prepublishOnly": "npm ci && npm test",
     "test": "cd demo && npm ci && netlify build --cwd . --offline && cd .. && node --test"
   },
   "repository": {


### PR DESCRIPTION
The last release-please release failed *again*, this time because we didn't install NPM packages before running `npm publish`. This PR replaces the `prepublishOnly` script with the one from our node template, because we know that works + because it's the same across all our other projects:

https://github.com/netlify/node-template/blob/10125d557201ac7efdd72c0521cf6f7aec89a15c/%7B%7Bcookiecutter.project_slug%7D%7D/package.json#L16
