### PR TITLE
ci: add missing Kodiak and Stalebot workflows

### DIFF
--- a/.github/.kodiak.toml
+++ b/.github/.kodiak.toml
@@ -1,0 +1,4 @@
+version = 1
+
+[approve]
+auto_approve_usernames = ["renovate"]

--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,20 @@
+name: 'Mark and close stale issues'
+on:
+  schedule:
+    - cron: '30 1 * * *' # runs daily at 1:30 https://crontab.guru/#30_1_*_*_*
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          exempt-issue-labels: 'WIP,security,action_item,never_stale'
+          days-before-issue-stale: 365
+          stale-issue-label: 'stale'
+          stale-issue-message:
+            'This issue has been automatically marked as stale because it has not had activity in 1 year. It will be
+            closed in 7 days if no further activity occurs. Thanks!'
+          days-before-issue-close: 7
+          close-issue-message: 'This issue was closed because it had no activity for over 1 year.'
+          days-before-pr-close: -1


### PR DESCRIPTION
- Kodiak will auto-approve Renovate PRs, so our Renovate automerge config will actually result in automerges.
- Stalebot will close stale (no activity) issues and PRs after 1 year, with a warning comment 1 week before that.