### PR TITLE
fix: correct checking for runtime version installed in the project and provide example API endpoint in code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ export async function netlifyCommonEngineHandler(request: Request, context: any)
   // Example API endpoints can be defined here.
   // Uncomment and define endpoints as necessary.
   // const pathname = new URL(request.url).pathname;
-  // if (pathname = '/api/hello') {
+  // if (pathname === '/api/hello') {
   //   return Response.json({ message: 'Hello from the API' });
   // }
 
@@ -145,7 +145,7 @@ export async function netlifyAppEngineHandler(request: Request): Promise<Respons
   // Example API endpoints can be defined here.
   // Uncomment and define endpoints as necessary.
   // const pathname = new URL(request.url).pathname;
-  // if (pathname = '/api/hello') {
+  // if (pathname === '/api/hello') {
   //   return Response.json({ message: 'Hello from the API' });
   // }
 

--- a/src/helpers/getPackageVersion.js
+++ b/src/helpers/getPackageVersion.js
@@ -1,3 +1,5 @@
+const { createRequire } = require('node:module')
+
 const { readJSON } = require('fs-extra')
 
 /**
@@ -29,8 +31,8 @@ module.exports.getAngularVersion = getAngularVersion
 const getAngularRuntimeVersion = async function (root) {
   let packagePath
   try {
-    // eslint-disable-next-line n/no-missing-require
-    packagePath = require.resolve('@netlify/angular-runtime/package.json', { paths: [root] })
+    const siteRequire = createRequire(root)
+    packagePath = siteRequire.resolve('@netlify/angular-runtime/package.json')
   } catch {
     // module not found
     return

--- a/src/helpers/getPackageVersion.js
+++ b/src/helpers/getPackageVersion.js
@@ -1,4 +1,5 @@
 const { createRequire } = require('node:module')
+const { join } = require('node:path/posix')
 
 const { readJSON } = require('fs-extra')
 
@@ -31,7 +32,7 @@ module.exports.getAngularVersion = getAngularVersion
 const getAngularRuntimeVersion = async function (root) {
   let packagePath
   try {
-    const siteRequire = createRequire(root)
+    const siteRequire = createRequire(join(root, ':internal:'))
     packagePath = siteRequire.resolve('@netlify/angular-runtime/package.json')
   } catch {
     // module not found

--- a/src/helpers/serverModuleHelpers.js
+++ b/src/helpers/serverModuleHelpers.js
@@ -127,7 +127,7 @@ const fixServerTs = async function ({ angularVersion, siteRoot, failPlugin, fail
     )
   } else if (!satisfies(angularRuntimeVersionInstalledByUser, '>=2.2.0', { includePrerelease: true })) {
     failBuild(
-      `Angular@19 SSR on Netlify requires '@netlify/angular-runtime' version 2.2.0 or later to be installed. Found version "${angularRuntimeVersionInstalledByUser}. Please update it to version 2.2.0 or later and try again.`,
+      `Angular@19 SSR on Netlify requires '@netlify/angular-runtime' version 2.2.0 or later to be installed. Found version "${angularRuntimeVersionInstalledByUser}". Please update it to version 2.2.0 or later and try again.`,
     )
   }
 

--- a/src/helpers/serverModuleHelpers.js
+++ b/src/helpers/serverModuleHelpers.js
@@ -16,6 +16,13 @@ import { render } from '@netlify/angular-runtime/common-engine'
 const commonEngine = new CommonEngine()
 
 export async function netlifyCommonEngineHandler(request: Request, context: any): Promise<Response> {
+  // Example API endpoints can be defined here.
+  // Uncomment and define endpoints as necessary.
+  // const pathname = new URL(request.url).pathname;
+  // if (pathname === '/api/hello') {
+  //   return Response.json({ message: 'Hello from the API' });
+  // }
+
   return await render(commonEngine)
 }
 `
@@ -28,6 +35,13 @@ const angularAppEngine = new AngularAppEngine()
 
 export async function netlifyAppEngineHandler(request: Request): Promise<Response> {
   const context = getContext()
+
+  // Example API endpoints can be defined here.
+  // Uncomment and define endpoints as necessary.
+  // const pathname = new URL(request.url).pathname;
+  // if (pathname === '/api/hello') {
+  //   return Response.json({ message: 'Hello from the API' });
+  // }
 
   const result = await angularAppEngine.handle(request, context)
   return result || new Response('Not found', { status: 404 })


### PR DESCRIPTION
- update readme and fix wrong code sample - we want to compare `pathname` not assign it doh
- update snippets that become part of error message when incompatible `server.ts` is found
- fix check for user-installed `@netlify/angular-runtime` version (current one doesn't actually do anything, because it somehow is able to resolve plugin installed in `<project-dir>/.netlify/plugins/node_modules` despite using `paths` param - probably related to `require.cache` (?) )