### PR TITLE
fix: provide failBuild to getProject calls

### DIFF
--- a/src/helpers/fixOutputDir.js
+++ b/src/helpers/fixOutputDir.js
@@ -5,7 +5,7 @@ const { getProject } = require('./setUpEdgeFunction')
 
 const fixOutputDir = async function ({ failBuild, failPlugin, siteRoot, PUBLISH_DIR, IS_LOCAL, netlifyConfig }) {
   const angularJson = getAngularJson({ failPlugin, siteRoot })
-  const project = getProject(angularJson)
+  const project = getProject(angularJson, failBuild)
 
   const { outputPath } = project.architect.build.options
 

--- a/src/helpers/serverModuleHelpers.js
+++ b/src/helpers/serverModuleHelpers.js
@@ -107,7 +107,7 @@ const fixServerTs = async function ({ angularVersion, siteRoot, failPlugin, fail
 
   const angularJson = getAngularJson({ failPlugin, siteRoot })
 
-  const project = getProject(angularJson)
+  const project = getProject(angularJson, failBuild)
   const {
     architect: { build },
   } = project

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ module.exports = {
     const siteRoot = getAngularRoot({ failBuild, netlifyConfig })
     const angularJson = getAngularJson({ failPlugin, siteRoot })
 
-    const project = getProject(angularJson)
+    const project = getProject(angularJson, failBuild)
     const {
       architect: { build },
     } = project


### PR DESCRIPTION
We've not been passing all the arguments to `getProject` resulting in

```
 TypeError: failBuild is not a function
     at getProject (/opt/build/repo/node_modules/@netlify/angular-runtime/src/helpers/setUpEdgeFunction.js:30:14)
```

kind of errors that hide actual error from the user and making it unnecessarily difficult to see underlying problem

fixes https://github.com/netlify/angular-runtime/issues/246
fixes https://linear.app/netlify/issue/FRB-1619/angular-19-ssr-and-the-angular-runtime